### PR TITLE
Homework_4/script

### DIFF
--- a/homework_4/eventsettlement/go.mod
+++ b/homework_4/eventsettlement/go.mod
@@ -1,0 +1,5 @@
+module eventsettlement
+
+go 1.16
+
+require github.com/pkg/errors v0.9.1

--- a/homework_4/eventsettlement/go.sum
+++ b/homework_4/eventsettlement/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/homework_4/eventsettlement/main.go
+++ b/homework_4/eventsettlement/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const activeBetsPath = "http://127.0.0.1:8082/bets?status=active"
+const eventPath = "http://127.0.0.1:8081/event/update"
+
+type betDto struct {
+	Id                   string  `json:"id"`
+	Status               string  `json:"status"`
+	SelectionId          string  `json:"selectionId"`
+	SelectionCoefficient float64 `json:"selectionCoefficient"`
+	Payment              float64 `json:"payment"`
+	Payout               float64 `json:"payout"`
+}
+
+type eventUpdateDto struct {
+	Id      string `json:"id"`
+	Outcome string `json:"outcome"`
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	client := http.Client{Timeout: time.Second * 5}
+	response, err := client.Get(activeBetsPath)
+	if err != nil {
+		log.Fatal(
+			errors.WithMessage(err, "error while sending GET request to Bets Api"),
+		)
+	}
+	bodyContent, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Fatal(
+			errors.WithMessage(err, "error while reading response from Bets Api"),
+		)
+	}
+
+	var decodedBets []betDto
+	err = json.Unmarshal(bodyContent, &decodedBets)
+	if err != nil {
+		log.Fatal(
+			errors.WithMessage(err, "error while decoding response from Bets Api"),
+		)
+	}
+
+	selectionIds := map[string]bool{}
+	for _, bet := range decodedBets {
+		selectionIds[bet.SelectionId] = true
+	}
+
+	for selectionId := range selectionIds {
+		var outcome string
+		if rand.Float64() > 0.5 {
+			outcome = "lost"
+		} else {
+			outcome = "won"
+		}
+
+		eventUpdate := &eventUpdateDto{
+			Id:      selectionId,
+			Outcome: outcome,
+		}
+
+		eventUpdateJson, err := json.Marshal(eventUpdate)
+		if err != nil {
+			log.Fatal(
+				errors.WithMessage(err, "failed to marshal an event update"),
+			)
+		}
+
+		reader := bytes.NewReader(eventUpdateJson)
+
+		post, err := client.Post(eventPath, "text/json", reader)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println(post)
+	}
+}


### PR DESCRIPTION
Part of homework 4 containing script which uses endpoints made in other parts of homework.

This PR also contains unreviewed `bet-acceptance` and `bets` Apis, but the script couldn't be tested without them.

For testing you can use script located at `homework_3/03_project/intializedb.sh` to initialize the database. Then run Controller and Calculator components following with running `bet-acceptance`, `bets` and `event_api` Apis

Example request towards bet-acceptance Api for populating database: 
```json
{
    "CustomerId": "6e90ed09-5815-4b93-72a4-a8048ead4aa5",
    "SelectionId": "bad76754-7c4c-4b93-50cb-14d17c51c372",
    "SelectionCoefficient": 6.30,
    "Payment": 44.195
}
```
Once enough bets were sent to Api, run `homework_4/eventsettlement/main.go` to test script.